### PR TITLE
Faster resize in image_ext_imagick

### DIFF
--- a/admin/include/image.class.php
+++ b/admin/include/image.class.php
@@ -589,7 +589,7 @@ class image_ext_imagick implements imageInterface
     $this->height = $height;
 
     $this->add_command('filter', 'Lanczos');
-    $this->add_command('resize', $width.'x'.$height.'!');
+    $this->add_command('thumbnail', $width.'x'.$height.'!');
     return true;
   }
 


### PR DESCRIPTION
Replaced 'resize' with 'thumbnail'. Thumbnail is much faster on large files (e.g. from DSLRs) than 'resize' by using box downsampling to get near the final size but then switches back to the specified filter for the final resize step. No loss in quality but significant speedup (~2x) on 22 MPixel images. Tested on my own piwigo installation.